### PR TITLE
[v1.0] Publishing version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# MPI-Wrapper for C++17
+# MPI-wrapper for C++17
+![license MIT](https://img.shields.io/badge/license-MIT-lightgrey.svg)
+![version 1.0](https://img.shields.io/badge/version-1.0-green.svg)
 
-This is a thin C++17 wrapper around the MPI API for C.
+A thin and modern C++17 wrapper around the pure-C implementation for the
+[Message Passing Interface](https://www.mpi-forum.org/) (MPI) standard.
+
+## Motivation
+Due to the lack of an official C++ specification or implementation for the MPI standard,
+developers have no alternatives but to keep using the low-level C API to achieve
+software parallelization with MPI. Although realible and extremely portable, the
+functions defined by the standard are not really easy to use or understand.
+
+This project focuses on wrapping the MPI standard functions into clean, elegant,
+type-safe and user-friendly interfaces, by exploring modern C++17's language features
+and idioms without the introduction of significant run-time overhead to the routines.
+Nonetheless, this library has no aim to provide direct mappings of the C API into
+C++ functions, namespaces or classes.
+
+This library is best used by developers who are already familiar with the MPI standard
+and functions, but is looking for a C++ idiomatic alternative. Be advised that not
+every feature are guaranteed to be supported.
+
+## Install
+The library requires any MPI implementation and MPI-compatible C++-compiler to be
+installed in your system. As a header-only library, you can directly download or
+copy the files into your own project or clone it following the steps below:
+```bash
+git clone https://github.com/rodriados/mpiwcpp17
+```
+
+## Usage
+To use the project, you can copy source files into your own project or install it
+in your system and then reference it in your code:
+```cpp
+#include <mpiwcpp17.h>
+```

--- a/src/mpiwcpp17.h
+++ b/src/mpiwcpp17.h
@@ -1,0 +1,22 @@
+/**
+ * A thin C++17 wrapper for MPI.
+ * @file The project's main header file.
+ * @author Rodrigo Siqueira <rodriados@gmail.com>
+ * @copyright 2022-present Rodrigo Siqueira
+ */
+#pragma once
+
+#include <mpiwcpp17/version.h>
+#include <mpiwcpp17/environment.hpp>
+
+#include <mpiwcpp17/global.hpp>
+
+#include <mpiwcpp17/collective.hpp>
+#include <mpiwcpp17/communicator.hpp>
+#include <mpiwcpp17/datatype.hpp>
+#include <mpiwcpp17/error.hpp>
+#include <mpiwcpp17/exception.hpp>
+#include <mpiwcpp17/functor.hpp>
+#include <mpiwcpp17/process.hpp>
+#include <mpiwcpp17/status.hpp>
+#include <mpiwcpp17/tag.hpp>


### PR DESCRIPTION
Publishes the project's version `1.0`.

This is the first public version and contains the first MPI wrappers: the basic machinery needed for supporting some collective operations such as `reduce`, `gather` and `scatter`.